### PR TITLE
JWW User Story 33

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,16 +1,9 @@
 class Admin::OrdersController < Admin::BaseController
-  before_action :require_admin
 
   def update
     @order = Order.find(params[:id])
     if @order.update({status: 2})
       flash[:success] = 'Order Shipped'
     end
-  end
-
-  private
-
-  def require_admin
-    render file: "/public/404" unless current_admin?
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -4,6 +4,7 @@ class Admin::OrdersController < Admin::BaseController
     @order = Order.find(params[:id])
     if @order.update({status: 2})
       flash[:success] = 'Order Shipped'
+      redirect_to '/admin'
     end
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,16 @@
+class Admin::OrdersController < Admin::BaseController
+  before_action :require_admin
+
+  def update
+    @order = Order.find(params[:id])
+    if @order.update({status: 2})
+      flash[:success] = 'Order Shipped'
+    end
+  end
+
+  private
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -2,10 +2,13 @@
   <section class="activeOrders">
     <% @orders.by_status.each do |order| %>
       <div id="order_<%= order.id %>">
-       <p><%= link_to "#{order.name}", "/admin/users/#{order.user.id}" %></p>
-       <p><%= order.id  %></p>
-       <p><%= order.status  %></p>
-       <p><%= order.created_at.to_formatted_s(:long) %></p>
+        <p><%= link_to "#{order.name}", "/admin/users/#{order.user.id}" %></p>
+        <p><%= order.id  %></p>
+        <p><%= order.status  %></p>
+        <p><%= order.created_at.to_formatted_s(:long) %></p>
+        <% if order.status == 'packaged' %>
+          <%= link_to 'Ship Order', "/admin/orders/#{order.id}", method: :patch %>
+        <% end %>
       </div>
     <% end %>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     get "/", to: "dashboard#index"
     get "/users", to: "users#index"
     get "/users/:id", to: "users#show"
+    patch "/orders/:id", to:"orders#update"
     resources :merchants, only: [:index, :update]
   end
 

--- a/spec/features/admin/orders/ship_an_order_spec.rb
+++ b/spec/features/admin/orders/ship_an_order_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin', type: :feature do
+  describe 'When I log into my dashboard and see orders ready to ship' do
+    it "I can click a button to change the order status to shipped" do
+
+      user = create(:admin_user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      item_order1 = create(:random_item_order)
+      order = item_order1.order
+      item_order2 = create(:random_item_order)
+      order1 = item_order2.order
+      order1.update(status: 0)
+      item_order3 = create(:random_item_order)
+      order2 = item_order3.order
+      order2.update(status: 0)
+
+      visit '/admin'
+
+      within("div#order_#{order.id}") do
+        expect(page).to_not have_button('Ship Order')
+      end
+
+      within("div#order_#{order1.id}") do
+        expect(page).to have_link('Ship Order')
+        expect(page).to have_content('packaged')
+        click_link 'Ship Order'
+        visit '/admin'
+        expect(page).to have_content('shipped')
+      end
+
+      within("div#order_#{order2.id}") do
+        expect(page).to have_link('Ship Order')
+        expect(page).to have_content('packaged')
+        click_link 'Ship Order'
+        visit '/admin'
+        expect(page).to have_content('shipped')
+      end
+
+    end
+  end
+
+  describe 'After an order ships' do
+    it 'the user can longer cancel it' do
+      item_order2 = create(:random_item_order)
+      order1 = item_order2.order
+      order1.update(status: 2)
+      user1 = order1.user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+      visit "/profile/orders"
+
+      within("section#order-#{order1.id}") do
+        expect(page).to_not have_content('Cancel Order')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add functionality for an admin to ship an order when it's status is `packaged`.

Completes User Story #

33

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
```
User Story 33, Admin can "ship" an order

As an admin user
When I log into my dashboard, "/admin"
Then I see any "packaged" orders ready to ship.
Next to each order I see a button to "ship" the order.
When I click that button for an order, the status of that order changes to "shipped"
And the user can no longer "cancel" the order.
```
## RSpec Results
```
Finished in 8.07 seconds (files took 2.82 seconds to load)
150 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/2module/projects/monster_shop_1911/coverage. 2286 / 2286 LOC (100.0%) covered.
```
