### PR TITLE
Da story 30

### DIFF
--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -31,12 +31,7 @@ class Profile::OrdersController < Profile::BaseController
 
   def update
     order = Order.find(params[:id])
-
-    # fulfilled = order.item_orders.where(status: :fulfilled)
-
-    order.update(status: 3)
-    order.item_orders.update(status: 'unfulfilled')
-
+    order.cancel
     flash[:success] = "Your order has been cancelled."
     redirect_to "/profile"
   end

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -31,8 +31,12 @@ class Profile::OrdersController < Profile::BaseController
 
   def update
     order = Order.find(params[:id])
-    order.cancel
-    flash[:success] = "Your order has been cancelled."
+    unless order.cancelled? || order.shipped?
+      order.cancel
+      flash[:success] = "Your order has been cancelled."
+    else
+      flash[:error] = "Unable to cancel an order that is already #{order.status}"
+    end
     redirect_to "/profile"
   end
 

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -29,6 +29,17 @@ class Profile::OrdersController < Profile::BaseController
     end
   end
 
+  def update
+    order = Order.find(params[:id])
+
+    # fulfilled = order.item_orders.where(status: :fulfilled)
+
+    order.update(status: 3)
+    order.item_orders.update(status: 'unfulfilled')
+
+    flash[:success] = "Your order has been cancelled."
+    redirect_to "/profile"
+  end
 
   private
 

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -8,4 +8,11 @@ class ItemOrder <ApplicationRecord
   def subtotal
     price * quantity
   end
+
+  def restock
+    unless status == "unfulfilled"
+      item.increment!(:inventory, quantity)
+      update(status: "unfulfilled")
+    end
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,6 +6,10 @@ class Order <ApplicationRecord
   has_many :item_orders
   has_many :items, through: :item_orders
 
+  def self.by_status
+    order(status: :asc)
+  end
+
   def grandtotal
     item_orders.sum('price * quantity')
   end
@@ -14,7 +18,11 @@ class Order <ApplicationRecord
     items.sum(:quantity)
   end
 
-  def self.by_status
-    order(status: :asc)
+  def cancel
+    update(status: "cancelled")
+    item_orders.where(status: "fulfilled").each do |item_order|
+      item_order.item.increment!(:inventory, item_order.quantity)
+    end
+    item_orders.update(status: "unfulfilled")
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -21,8 +21,7 @@ class Order <ApplicationRecord
   def cancel
     update(status: "cancelled")
     item_orders.where(status: "fulfilled").each do |item_order|
-      item_order.item.increment!(:inventory, item_order.quantity)
+      item_order.restock
     end
-    item_orders.update(status: "unfulfilled")
   end
 end

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -61,5 +61,5 @@
 </section>
 
 <% if @order.status != 'shipped' %>
-  <%= link_to 'Cancel Order', "/profile/orders/#{@order.id}" %>
+  <%= link_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :patch %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     get '/edit/pw', to: 'users#edit_pw'
     patch '/user', to: 'users#update'
     patch '/user/pw', to: 'security#update'
-    resources :orders, only: [:index, :show, :new, :create]
+    resources :orders, only: [:index, :show, :new, :create, :update]
   end
 
   namespace :admin do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200223200607) do
+ActiveRecord::Schema.define(version: 20200223211227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,8 @@ ActiveRecord::Schema.define(version: 20200223200607) do
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "merchant_id"
+    t.index ["merchant_id"], name: "index_users_on_merchant_id"
   end
 
   add_foreign_key "item_orders", "items"
@@ -90,4 +92,5 @@ ActiveRecord::Schema.define(version: 20200223200607) do
   add_foreign_key "items", "merchants"
   add_foreign_key "orders", "users"
   add_foreign_key "reviews", "items"
+  add_foreign_key "users", "merchants"
 end

--- a/spec/features/admin/users/user_profile_page_spec.rb
+++ b/spec/features/admin/users/user_profile_page_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'As an admin', type: :feature do
   describe "When I visit a user's profile page" do
     before :each do
-      @user = create(:admin_user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      user = create(:admin_user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       @user1 = create(:regular_user)
       @user2 = create(:merchant_user)
@@ -20,7 +20,7 @@ RSpec.describe 'As an admin', type: :feature do
       expect(page).to have_content(@user1.zip)
       expect(page).to have_content(@user1.email)
       expect(page).to have_content(@user1.role)
-      expect(page).to_not have_content('Edit Profile')
+      expect(page).to_not have_link('Edit Profile')
 
       visit admin_user_path(@user2)
 
@@ -31,7 +31,7 @@ RSpec.describe 'As an admin', type: :feature do
       expect(page).to have_content(@user2.zip)
       expect(page).to have_content(@user2.email)
       expect(page).to have_content(@user2.role)
-      expect(page).to_not have_content('Edit Profile')
+      expect(page).to_not have_link('Edit Profile')
     end
   end
 end

--- a/spec/features/users/orders/update_spec.rb
+++ b/spec/features/users/orders/update_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'profile orders show page', type: :feature do
       expect(@item_order2.status).to eq("unfulfilled")
       expect(@merchant.items.first.inventory).to eq(100)
       expect(@merchant.items.second.inventory).to eq(200)
-      expect(@order1.status).to eq("cancelled")
       expect(page).to have_content("Your order has been cancelled.")
 
       visit "/profile/orders"
@@ -60,7 +59,6 @@ RSpec.describe 'profile orders show page', type: :feature do
       expect(@merchant.items.first.inventory).to eq(200)
       expect(@merchant.items.second.inventory).to eq(250)
       expect(@merchant.items.third.inventory).to eq(300)
-      expect(@semi_fulfilled_order.status).to eq("cancelled")
       expect(page).to have_content("Your order has been cancelled.")
 
       visit "/profile/orders"

--- a/spec/features/users/orders/update_spec.rb
+++ b/spec/features/users/orders/update_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'profile orders show page', type: :feature do
+  describe 'As a user' do
+    before :each do
+      user = create(:regular_user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      @merchant = create(:random_merchant)
+
+      item1 = create(:random_item, merchant: @merchant, inventory: 100)
+      item2 = create(:random_item, merchant: @merchant, inventory: 200)
+      item3 = create(:random_item, merchant: @merchant, inventory: 300)
+
+      @order1 = create(:random_order, user: user)
+      @order2 = create(:random_order, user: user)
+      @semi_fulfilled_order = create(:random_order, user: user)
+
+      @item_order1 = create(:random_item_order, item: item1, order: @order1, price: item1.price, quantity: 3)
+      @item_order2 = create(:random_item_order, item: item2, order: @order1, price: item2.price, quantity: 7)
+
+      @item_order3 = create(:random_item_order, item: item3, order: @order2, price: item3.price, quantity: 12)
+
+      create(:random_item_order, item: item1, order: @semi_fulfilled_order, price: item1.price, quantity: 100, status: 1)
+      create(:random_item_order, item: item2, order: @semi_fulfilled_order, price: item2.price, quantity: 50, status: 1)
+      create(:random_item_order, item: item3, order: @semi_fulfilled_order, price: item3.price, quantity: 25)
+    end
+
+    it "I can cancel my order" do
+      visit "/profile/orders/#{@order1.id}"
+
+      expect(@order1.status).to eq("pending")
+
+      click_link("Cancel Order")
+
+      expect(current_path).to eq("/profile")
+      expect(@item_order1.status).to eq("unfulfilled")
+      expect(@item_order2.status).to eq("unfulfilled")
+      expect(@merchant.items.first.inventory).to eq(100)
+      expect(@merchant.items.second.inventory).to eq(200)
+      expect(@order1.status).to eq("cancelled")
+      expect(page).to have_content("Your order has been cancelled.")
+
+      visit "/profile/orders"
+
+      within("#order-#{@order1.id}") { expect(page).to have_content("Status: cancelled") }
+     end
+
+    it "fulfilled items are restocked when I cancel my order" do
+      visit "/profile/orders/#{@semi_fulfilled_order.id}"
+
+      expect(@semi_fulfilled_order.status).to eq("pending")
+
+      click_link("Cancel Order")
+
+      expect(current_path).to eq("/profile")
+      @semi_fulfilled_order.item_orders.each do |item_order|
+        expect(item_order.status).to eq("unfulfilled")
+      end
+      expect(@merchant.items.first.inventory).to eq(200)
+      expect(@merchant.items.second.inventory).to eq(250)
+      expect(@merchant.items.third.inventory).to eq(300)
+      expect(@semi_fulfilled_order.status).to eq("cancelled")
+      expect(page).to have_content("Your order has been cancelled.")
+
+      visit "/profile/orders"
+
+      within("#order-#{@semi_fulfilled_order.id}") { expect(page).to have_content("Status: cancelled") }
+     end
+
+  end
+end

--- a/spec/features/users/orders/update_spec.rb
+++ b/spec/features/users/orders/update_spec.rb
@@ -66,5 +66,25 @@ RSpec.describe 'profile orders show page', type: :feature do
       within("#order-#{@semi_fulfilled_order.id}") { expect(page).to have_content("Status: cancelled") }
      end
 
+    it "I can't cancel a shipped order" do
+      visit "/profile/orders/#{@semi_fulfilled_order.id}"
+
+      @semi_fulfilled_order.item_orders.last.update(status: 'fulfilled')
+      @semi_fulfilled_order.update(status: "shipped")
+
+      click_link("Cancel Order")
+
+      expect(current_path).to eq("/profile")
+
+      expect(@merchant.items.first.inventory).to eq(100)
+      expect(@merchant.items.second.inventory).to eq(200)
+      expect(@merchant.items.third.inventory).to eq(300)
+      expect(page).to have_content("Unable to cancel an order that is already")
+
+      visit "/profile/orders"
+
+      within("#order-#{@semi_fulfilled_order.id}") { expect(page).to have_content("Status: shipped") }
+     end
+
   end
 end

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -22,6 +22,16 @@ describe ItemOrder, type: :model do
 
       expect(item_order_1.subtotal).to eq(200)
     end
+
+    it 'restock' do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user: create(:regular_user))
+      item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2, status: "fulfilled")
+      item_order_1.restock
+      expect(item_order_1.status).to eq("unfulfilled")
+      expect(item_order_1.item.inventory).to eq(14)
+    end
   end
 
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -35,6 +35,15 @@ describe Order, type: :model do
     it "item_count" do
       expect(@order_1.item_count).to eq(5)
     end
+    it "cancel" do
+      @order_1.item_orders.second.update(status: "fulfilled")
+      @order_1.cancel
+
+      expect(@order_1.status).to eq("cancelled")
+      expect(@order_1.item_orders.second.status).to eq("unfulfilled")
+      expect(Item.first.inventory).to eq(12)
+      expect(Item.last.inventory).to eq(35)
+    end
   end
 
   describe 'model class methods' do


### PR DESCRIPTION
## Description
Completes User Story #30

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Adds order cancellation - cancelling an order changes the status of the order, all of its order items, and restocks any fulfilled items' inventories
- functionality to cancel an order lives in profile::orders controller - feels a little weird but "cancelling" is the only way for a user to update the status of an order as far as I know
  - adds a `cancel` model method to `order` and `restock` method to `item_order`
    - currently uses an `each` block to iterate, not sure how to avoid that
```
User Story 30, User cancels an order

As a registered user
When I visit an order's show page
I see a button or link to cancel the order 
When I click the cancel button for an order, the following happens:
- Each row in the "order items" table is given a status of "unfulfilled"
- The order itself is given a status of "cancelled"
- Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
- I am returned to my profile page
- I see a flash message telling me the order is now cancelled
- And I see that this order now has an updated status of "cancelled"
```

## RSpec Results
```
161 examples, 0 failures

Coverage report generated for RSpec - 2480 / 2480 LOC (100.0%) covered.
```
*hard to test in rails s until story 50 is implemented - have to change an item_order's status to "fulfilled" in rails c