### PR TITLE
DA Story 49

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -157,4 +157,12 @@ tr:nth-child(even) {
   background-color: #F0F8FF;
 }
 
-
+.small {
+  border-radius: 5px;
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/controllers/merchant/base_controller.rb
+++ b/app/controllers/merchant/base_controller.rb
@@ -1,0 +1,7 @@
+class Merchant::BaseController < ApplicationController
+  before_action :require_merchant
+
+  def require_merchant
+    render file: "/public/404" unless current_merchant?
+  end
+end

--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,13 +1,6 @@
-class Merchant::DashboardController < ApplicationController
-  before_action :require_merchant
-
+class Merchant::DashboardController < Merchant::BaseController
+  
   def index
     @merchant = current_user.merchant
-  end
-
-  private
-
-  def require_merchant
-    render file: "/public/404" unless current_merchant?
   end
 end

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,8 +1,8 @@
-class Merchant::ItemsController < ApplicationController
+class Merchant::ItemsController < Merchant::BaseController
 
   def update
     item = Item.find(params[:id])
-    merchant = item.merchant 
+    merchant = item.merchant
     item.toggle!(:active?)
     redirect_to "/merchants/#{merchant.id}/items"
     if item.active?

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,6 +1,12 @@
 class Merchant::OrdersController < Merchant::BaseController
 
   def show
-    @order = Order.find(params[:id])
+    @order = Order.where(id: params[:id]).take
+    render file: "/public/404" if no_order
   end
+
+  private
+    def no_order
+      @order.nil? || @order.item_orders.by_merchant(current_user.merchant.id).empty?
+    end
 end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,7 +1,7 @@
 class Merchant::OrdersController < Merchant::BaseController
 
   def show
-    @order = Order.where(id: params[:id]).take
+    @order = Order.find_by(id: params[:id])
     render file: "/public/404" if no_order
   end
 

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,6 +1,6 @@
 class Merchant::OrdersController < Merchant::BaseController
 
   def show
-
+    @order = Order.find(params[:id])
   end
 end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,0 +1,6 @@
+class Merchant::OrdersController < Merchant::BaseController
+
+  def show
+
+  end
+end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -5,6 +5,13 @@ class ItemOrder <ApplicationRecord
   belongs_to :item
   belongs_to :order
 
+  def self.by_merchant(id)
+    self
+      .all
+      .joins(:item)
+      .where("items.merchant_id = #{id}")
+  end
+
   def subtotal
     price * quantity
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,7 +7,7 @@ class Order <ApplicationRecord
   has_many :items, through: :item_orders
 
   def self.by_status
-    order(status: :asc)
+    order(:status, id: :asc)
   end
 
   def grandtotal

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,0 +1,41 @@
+<section class = "shipping-address">
+  <h1 align = "center">Recipient Info</h1>
+  <center>
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>Address</th>
+      <th>City</th>
+      <th>State</th>
+      <th>Zip</th>
+    </tr>
+    <tr>
+      <td><p><%= @order.name %> </p></td>
+      <td><p><%= @order.address %> </p></td>
+      <td><p><%= @order.city %> </p></td>
+      <td><p><%= @order.state %> </p></td>
+      <td><p><%= @order.zip %> </p></td>
+    </tr>
+  </table>
+</section>
+
+<h1 align = "center">Order Info</h1>
+<center>
+  <table>
+    <tr>
+      <th>Image</th>
+      <th>Item</th>
+      <th>Price</th>
+      <th>Quantity</th>
+    </tr>
+  <% @order.item_orders.by_merchant(current_user.merchant.id).each do |item_order|%>
+    <tr>
+    <section id = "item-<%=item_order.item_id%>">
+        <td><p class='small'><%= link_to image_tag(item_order.item.image), item_path(item_order.item.id) %></p></td>
+        <td><p><%= link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></td>
+        <td><p><%= number_to_currency(item_order.price)%></p></td>
+        <td><p><%= item_order.quantity%></p></td>
+      </section>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/:id/items', to: 'items#show'
     resources :items, only: %i[update destroy]
+    resources :orders, only: [:show]
   end
 
   get '/merchants/:merchant_id/items', to: 'items#index'

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant employee orders show page', type: :feature do
+  describe 'As a merchant' do
+    before :each do
+      user = create(:regular_user)
+      @shop = create(:random_merchant)
+      @other_shop = create(:random_merchant)
+
+      employee = create(:merchant_user, merchant: @shop)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(employee)
+
+      @item1 = create(:random_item, merchant: @shop)
+      @item2 = create(:random_item, merchant: @shop)
+      @item3 = create(:random_item, merchant: @other_shop)
+
+      @order1 = create(:random_order, user: user)
+      @order2 = create(:random_order, user: user)
+
+      @item_order1 = create(:random_item_order, item: @item1, order: @order1, price: @item1.price, quantity: 3)
+      @item_order2 = create(:random_item_order, item: @item2, order: @order1, price: @item2.price, quantity: 7)
+      @item_order3 = create(:random_item_order, item: @item3, order: @order2, price: @item3.price, quantity: 12)
+
+      visit "/merchants/orders/#{@order1.id}"
+    end
+
+    it "I can see the order information pertaining to my shop" do
+      expect(page).to have_content(@order1.name)
+      expect(page).to have_content(@order1.address)
+      within("#item-#{@item1.id}") do
+        expect(page).to have_link(@item1.name)
+        expect(page).to have_css("img[src*='#{@item1.image}']")
+        expect(page).to have_content(@item1.price)
+        expect(page).to have_content(@item_order1.quantity)
+      end
+      expect(page).to have_css("#item-#{@item2.id}")
+      expect(page).to_not have_css("#item-#{@item3.id}")
+    end
+
+  end
+end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'merchant employee orders show page', type: :feature do
       @item_order2 = create(:random_item_order, item: @item2, order: @order1, price: @item2.price, quantity: 7)
       @item_order3 = create(:random_item_order, item: @item3, order: @order2, price: @item3.price, quantity: 12)
 
-      visit "/merchants/orders/#{@order1.id}"
+      visit "/merchant/orders/#{@order1.id}"
     end
 
     it "I can see the order information pertaining to my shop" do

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'merchant employee orders show page', type: :feature do
       @item3 = create(:random_item, merchant: @other_shop)
 
       @order1 = create(:random_order, user: user)
-      @order2 = create(:random_order, user: user)
+      @order2 = create(:random_order, name: "NOT ME", address: "NOT HERE")
 
       @item_order1 = create(:random_item_order, item: @item1, order: @order1, price: @item1.price, quantity: 3)
       @item_order2 = create(:random_item_order, item: @item2, order: @order1, price: @item2.price, quantity: 7)
-      @item_order3 = create(:random_item_order, item: @item3, order: @order2, price: @item3.price, quantity: 12)
+      @item_order3 = create(:random_item_order, item: @item3, order: @order1, price: @item3.price, quantity: 12)
 
       visit "/merchant/orders/#{@order1.id}"
     end
@@ -27,6 +27,8 @@ RSpec.describe 'merchant employee orders show page', type: :feature do
     it "I can see the order information pertaining to my shop" do
       expect(page).to have_content(@order1.name)
       expect(page).to have_content(@order1.address)
+      expect(page).to_not have_content(@order2.name)
+      expect(page).to_not have_content(@order2.address)
       within("#item-#{@item1.id}") do
         expect(page).to have_link(@item1.name)
         expect(page).to have_css("img[src*='#{@item1.image}']")

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -13,7 +13,7 @@ describe ItemOrder, type: :model do
     it {should belong_to :order}
   end
 
-  describe 'instance methods' do
+  describe 'methods' do
     it 'subtotal' do
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
@@ -31,6 +31,24 @@ describe ItemOrder, type: :model do
       item_order_1.restock
       expect(item_order_1.status).to eq("unfulfilled")
       expect(item_order_1.item.inventory).to eq(14)
+    end
+
+    it "by_merchant" do
+      shop = create(:random_merchant)
+      other_shop = create(:random_merchant)
+
+      item1 = create(:random_item, merchant: shop)
+      item2 = create(:random_item, merchant: shop)
+      item3 = create(:random_item, merchant: other_shop)
+
+      order1 = create(:random_order)
+
+      item_order1 = create(:random_item_order, item: item1, order: order1, price: item1.price, quantity: 3)
+      item_order2 = create(:random_item_order, item: item2, order: order1, price: item2.price, quantity: 7)
+      item_order3 = create(:random_item_order, item: item3, order: order1, price: item3.price, quantity: 12)
+
+      expect(order1.item_orders.by_merchant(shop.id)).to eq([item_order1, item_order2])
+      expect(order1.item_orders.by_merchant(other_shop.id)).to eq([item_order3])
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -48,19 +48,13 @@ describe Order, type: :model do
 
   describe 'model class methods' do
     it 'order by status' do
-      item_order1 = create(:random_item_order)
-      item_order2 = create(:random_item_order)
-      item_order3 = create(:random_item_order)
-      item_order4 = create(:random_item_order)
-      item_order5 = create(:random_item_order)
-
+      order1 = create(:random_order)
+      order2 = create(:random_order, status: "cancelled")
+      order3 = create(:random_order, status: "packaged")
+      order4 = create(:random_order, status: "packaged")
+      order5 = create(:random_order, status: "shipped")
       sorted_orders = Order.by_status
-      expect(sorted_orders.count).to eq(5)
-      expect(sorted_orders[0]).to eq(item_order1.order)
-      expect(sorted_orders[1]).to eq(item_order2.order)
-      expect(sorted_orders[2]).to eq(item_order3.order)
-      expect(sorted_orders[3]).to eq(item_order4.order)
-      expect(sorted_orders[4]).to eq(item_order5.order)
+      expect(sorted_orders).to eq([order3, order4, order1, order5, order2])
     end
   end
 end


### PR DESCRIPTION
## Description
Completes User Story #49

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Adds merchant order show page: a merchant can see the recipient's name and address, as well as a list of items on the order from that merchant's shop - **not** items ordered from other shops

**Note**: `order by status` was failing again, so I decided to rewrite it. I'm not entirely sure what the test was checking before, but I think the new test is a better reflection of what the method does, and hopefully won't randomly fail anymore.
```
User Story 49, Merchant sees an order show page

As a merchant employee
When I visit an order show page from my dashboard
I see the recipients name and address that was used to create this order
I only see the items in the order that are being purchased from my merchant
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- an image of the item
- my price for the item
- the quantity the user wants to purchase
```

## RSpec Results
```
163 examples, 0 failures

Coverage report generated for RSpec - 2523 / 2523 LOC (100.0%) covered.
```
