### PR TITLE
Da us18 rework

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,11 +13,10 @@ class Item <ApplicationRecord
   validates_numericality_of :price, greater_than: 0
 
   def self.popular(limit, order)
-     Item.select("items.*, SUM(quantity) AS total")
-       .joins(:item_orders)
-       .group(:id)
-       .order("total #{order}")
-       .limit(limit)
+    left_outer_joins(:item_orders)
+      .group(:id)
+      .order("COALESCE(SUM(quantity), 0) #{order}")
+      .limit(limit)
   end
 
   def average_review

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item <ApplicationRecord
   def self.popular(limit, order)
     left_outer_joins(:item_orders)
       .group(:id)
-      .order("COALESCE(SUM(quantity), 0) #{order}")
+      .order("COALESCE(SUM(quantity), 0) #{order}, items.id")
       .limit(limit)
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,6 +6,7 @@
     </section>
   <% end %>
 </section>
+
 <% if @merchant %>
   <h1><%= link_to @merchant.name, "/merchants/#{@merchant.id}"%><span> Items</span></h1>
   <p align="center"><%= link_to "Add New Item", "/merchant/#{@merchant.id}/items/new" if @merchant && current_merchant_employee? %></p>
@@ -23,7 +24,6 @@
       <p>Inventory: <%= item.inventory %> </p>
       <% if item.active? %>
         <p>Active</p>
-
         <%= link_to "deactivate", "/merchant/items/#{item.id}/toggle", method: :patch  if @merchant && current_merchant_employee?%>
       <% else %>
         <p>Inactive</p>
@@ -34,6 +34,7 @@
     </section>
     <% end %>
 </section>
+
 <section id="least_popular"><h1>Least Popular Items</h1>
   <% @items.popular(5, 'asc').each.with_index do |item, index| %>
     <section id="bottom-<%= index + 1 %>">

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Items Index Page" do
 
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
-      @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?: false, inventory: 21)
     end
 
     it "all items or merchant names are links" do
@@ -104,24 +104,24 @@ RSpec.describe "Items Index Page" do
 
       within("#least_popular") do
         within("#bottom-1") do
+          expect(page).to have_link(@tire.name)
+          expect(page).to have_content("Total amount ordered: #{@tire.quantity_bought}")
+        end
+        within("#bottom-2") do
+          expect(page).to have_link(@pull_toy.name)
+          expect(page).to have_content("Total amount ordered: #{@pull_toy.quantity_bought}")
+        end
+        within("#bottom-3") do
           expect(page).to have_link(item7.name)
           expect(page).to have_content("Total amount ordered: #{item7.quantity_bought}")
         end
-        within("#bottom-2") do
+        within("#bottom-4") do
           expect(page).to have_link(item6.name)
           expect(page).to have_content("Total amount ordered: #{item6.quantity_bought}")
         end
-        within("#bottom-3") do
+        within("#bottom-5") do
           expect(page).to have_link(item5.name)
           expect(page).to have_content("Total amount ordered: #{item5.quantity_bought}")
-        end
-        within("#bottom-4") do
-          expect(page).to have_link(item4.name)
-          expect(page).to have_content("Total amount ordered: #{item4.quantity_bought}")
-        end
-        within("#bottom-5") do
-          expect(page).to have_link(item3.name)
-          expect(page).to have_content("Total amount ordered: #{item3.quantity_bought}")
         end
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -83,7 +83,7 @@ describe Item, type: :model do
       1.times { create(:random_item_order, item: item7, price: item1.price, quantity: 5) }
 
       expect(Item.popular(5, "desc")).to eq([super_item, item1, item2, item3, item4])
-      expect(Item.popular(5, "asc")).to eq([item7, item6, item5, item4, item3])
+      expect(Item.popular(5, "asc")).to eq([@chain, item7, item6, item5, item4])
     end
   end
 end


### PR DESCRIPTION
## Description
Fixes User Story #18

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Fixes `Item` class method `popular` to account for items that have no sales (no `ItemOrders`)
  - this is achieved with [SQL Coalesce](https://www.w3schools.com/sql/func_sqlserver_coalesce.asp)
```
User Story 18, Items Index Page Statistics

As any kind of user on the system
When I visit the items index page ("/items")
I see an area with statistics:
- the top 5 most popular items by quantity purchased, plus the quantity bought
- the bottom 5 least popular items, plus the quantity bought

"Popularity" is determined by total quantity of that item ordered
```

## RSpec Results
```
174 examples, 0 failures

Coverage report generated for RSpec - 2786 / 2786 LOC (100.0%) covered.
```
