### PR TITLE
Jww user story 61

### DIFF
--- a/app/controllers/admin/merchant_items_controller.rb
+++ b/app/controllers/admin/merchant_items_controller.rb
@@ -1,23 +1,24 @@
-class Merchant::ItemsController < Merchant::BaseController
-  before_action :require_employee, only: [:new, :create]
-  before_action :require_item_match, only: [:show, :edit, :update]
-
+class Admin::MerchantItemsController < Admin::BaseController
   def index
-    @merchant = Merchant.find(current_user.merchant.id)
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   def new
-    merchant = Merchant.find(params[:merchant_id])
+    merchant = Merchant.find(params[:id])
     @item = merchant.items.create(item_params)
   end
 
   def create
-    merchant = Merchant.find(params[:merchant_id])
+    merchant = Merchant.find(params[:id])
     params.delete :image if params[:image].blank?
     @item = merchant.items.create(item_params)
     if @item.save
       flash[:success] = "#{@item.name} has been saved."
-      redirect_to "/merchant/items"
+      redirect_to "/admin/merchants/#{merchant.id}/items"
     else
       flash.now[:error] = @item.errors.full_messages.to_sentence
       render :new
@@ -25,23 +26,24 @@ class Merchant::ItemsController < Merchant::BaseController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def update
+    @item = Item.find(params[:id])
+    merchant = @item.merchant
     if @item.update(item_params)
       flash[:success] = "#{@item.name} has been updated."
-      redirect_to "/merchant/items"
+      redirect_to "/admin/merchants/#{merchant.id}/items"
     else
       flash.now[:error] = @item.errors.full_messages.to_sentence
       render :edit
     end
   end
 
-  def show
-  end
-
   def destroy
-    item = Item.find_by(id: params[:id])
+    item = Item.find(params[:id])
+    merchant = item.merchant
     if !item
       flash[:error] = "Item already deleted."
     elsif item.no_orders?
@@ -50,23 +52,12 @@ class Merchant::ItemsController < Merchant::BaseController
     else
       flash[:error] = "Cannot delete an item with orders."
     end
-    redirect_to "/merchant/items"
+    redirect_to "/admin/merchants/#{merchant.id}/items"
   end
 
     private
 
     def item_params
       params.permit(:name,:description,:price,:inventory,:image)
-    end
-
-    def require_employee
-      authorized = params[:merchant_id] == current_user.merchant.id.to_s
-      render file: "/public/404" unless authorized
-    end
-
-    def require_item_match
-      @item = Item.find_by(id: params[:id])
-      authorized = @item && @item.merchant == current_user.merchant
-      render file: "/public/404" unless authorized
     end
 end

--- a/app/controllers/admin/toggle_items_controller.rb
+++ b/app/controllers/admin/toggle_items_controller.rb
@@ -1,0 +1,14 @@
+class Admin::ToggleItemsController < Admin::BaseController
+
+  def update
+    item = Item.find(params[:id])
+    merchant = item.merchant
+    item.toggle!(:active?)
+    if item.active?
+      flash[:success] = "#{item.name} is now available for sale."
+    else
+      flash[:error] = "#{item.name} is no longer for sale."
+    end
+    redirect_to "/admin/merchants/#{merchant.id}/items"
+  end
+end

--- a/app/views/admin/merchant_items/edit.html.erb
+++ b/app/views/admin/merchant_items/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: '/partials/merchant_items_edit', locals: {
+  item_path: "/admin/merchants/#{@item.merchant.id}/items/#{@item.id}"
+}  %>

--- a/app/views/admin/merchant_items/index.html.erb
+++ b/app/views/admin/merchant_items/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: '/partials/merchant_items', locals: {
-  new_item_path: "/admin/merchants/#{@items.first.merchant.id}/items",
-  items_path: "/admin/merchants/#{@items.first.merchant.id}/items",
+  new_item_path: "/admin/merchants/#{@merchant.id}/items",
+  items_path: "/admin/merchants/#{@merchant.id}/items",
   merchant_name: @merchant.name
 } %>

--- a/app/views/admin/merchant_items/index.html.erb
+++ b/app/views/admin/merchant_items/index.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: '/partials/merchant_items', locals: {
+  new_item_path: "/admin/merchants/#{@items.first.merchant.id}/items",
+  items_path: "/admin/merchants/#{@items.first.merchant.id}/items",
+  merchant_name: @merchant.name
+} %>

--- a/app/views/admin/merchant_items/new.html.erb
+++ b/app/views/admin/merchant_items/new.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: '/partials/merchant_items_new', locals: {
+  merchant_name: @item.merchant.name,
+  merchant_path: "/admin/merchants/#{@item.merchant.id}",
+  item_path: "/admin/merchants/#{@item.merchant.id}/items"
+}  %>

--- a/app/views/admin/merchant_items/show.html.erb
+++ b/app/views/admin/merchant_items/show.html.erb
@@ -1,0 +1,57 @@
+<h1><%= link_to @item.name, "/items/#{@item.id}" %></h1>
+<p align="center">Sold by: <%=link_to @item.merchant.name, "/admin/merchants/#{@item.merchant.id}" %> </p>
+<section align = "center" id = "average-rating">
+  <p>Average Rating: <%= @item.average_review %></p>
+</section>
+<center>
+  <section class = "item-show-grid">
+    <section class = "item-show-item">
+      <img src= <%= @item.image %>>
+    </section>
+    <section style="text-align:left" class = "item-show-item">
+      <p>Description: <%= @item.description %></p>
+      <p>Price: <%= number_to_currency(@item.price )%> </p>
+      <p>Inventory: <%= @item.inventory %> </p>
+      <% if @item.active? %>
+        <p style= "color:green">Active</p>
+      <% else %>
+        <p style= "color:red">Inactive</p>
+      <% end %>
+      <p><%= link_to "Edit Item", "/admin/merchants/#{@item.merchant.id}/items/#{@item.id}/edit" %></p>
+      <p><%= link_to "Delete Item", "/admin/merchants/#{@item.merchant.id}/items/#{@item.id}", method: :delete %></p>
+      <%= link_to "Add Review", "/items/#{@item.id}/reviews/new" %>
+    </section>
+  </section>
+</center>
+<center>
+<section class = "review-stats">
+  <%if @item.reviews.empty? %>
+    <h3>This item has not yet been reviewed.</h3>
+  <% else %>
+    <section class = "top-three-reviews">
+      <h2>Top 3 Reviews</h2>
+      <% @item.sorted_reviews(3, :desc).each do |review| %>
+        <h3><%= "#{review.rating}-#{review.title}" %></h3>
+      <% end %>
+    </section>
+    <section class = "bottom-three-reviews">
+      <h2>Bottom 3 Reviews</h2>
+      <% @item.sorted_reviews(3, :asc).each do |review| %>
+        <h3><%= "#{review.rating}-#{review.title}" %></h3>
+      <% end %>
+    </section>
+  </section>
+  <section class = "list-reviews">
+    <h2>All Reviews</h2>
+    <% @item.reviews.each do |review| %>
+      <section id= 'review-<%=review.id%>'>
+        <%= review.title %>
+        <%= review.content %>
+        Rating: <%= review.rating %>/5
+        <%= link_to "Edit", "/reviews/#{review.id}/edit" %>
+        <%= link_to "Delete", "/reviews/#{review.id}", method: :delete %>
+      </section>
+    <% end %>
+  <% end %>
+</section>
+</center>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: "/partials/merchant_dashboard", locals: {
-  path: "/admin/merchants/#{@merchant.id}/orders/"
+  path: "/admin/merchants/#{@merchant.id}/orders/",
+  items_path: "/admin/merchants/#{@merchant.id}/items"
 } %>

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: "/partials/merchant_dashboard", locals: {
-  path: "merchant/orders/"
+  path: "merchant/orders/",
+  items_path: "/merchant/items"
 } %>

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,21 +1,3 @@
-<h1>Edit <%=link_to @item.name, "/items/#{@item.id}" %></h1>
-<center>
-  <%= form_tag "/merchant/items/#{@item.id}", method: :patch  do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name, "#{@item.name}"%>
-
-    <%= label_tag :description %>
-    <%= text_field_tag :description, "#{@item.description}" %>
-
-    <%= label_tag :price %>
-    <%= text_field_tag :price, "#{@item.price}" %>
-
-    <%= label_tag :image %>
-    <%= text_field_tag :image, "#{@item.image}" %>
-
-    <%= label_tag :inventory %>
-    <%= number_field_tag :inventory, "#{@item.inventory}" %>
-
-    <%= submit_tag 'Update Item' %>
-  <% end %>
-</center>
+<%= render partial: '/partials/merchant_items_edit', locals: {
+  item_path: "/merchant/items/#{@item.id}"
+}  %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,23 +1,5 @@
-<h1>My Items - <%= link_to current_user.merchant.name, merchant_path(current_user.merchant.id) %></h1>
-<p align="center"><%= link_to "Add New Item", "/merchant/#{current_user.merchant.id}/items/new" %></p>
-
-<section class="grid-container">
-  <% @items.each do |item| %>
-    <section class = "grid-item" id= 'item-<%=item.id%>'>
-      <%= render partial: '/partials/item_info', locals: {item: item, path: merchant_item_path(item.id)}%>
-      <% if item.active? %>
-        <p>
-          Active -
-          <%= link_to "Deactivate", "/merchant/items/#{item.id}/toggle", method: :patch %>
-        </p>
-      <% else %>
-        <p>
-          Inactive -
-          <%= link_to "Activate", "/merchant/items/#{item.id}/toggle", method: :patch %>
-        </p>
-      <% end %>
-      <%= link_to "Edit", "/merchant/items/#{item.id}/edit", method: :get %>
-      <%= link_to "Delete", "/merchant/items/#{item.id}", method: :delete %>
-    </section>
-  <% end %>
-</section>
+<%= render partial: '/partials/merchant_items', locals: {
+  new_item_path: "/merchant/#{@merchant.id}/items",
+  items_path: "/merchant/items",
+  merchant_name: @merchant.name
+}  %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -1,24 +1,7 @@
-<h1>Create New Item For <%=link_to @item.merchant.name, "/merchants/#{@item.merchant.id}" %></h1>
-
-<center>
-  <%= form_tag "/merchant/#{@item.merchant.id}/items", method: :post do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name, @item.name %>
-
-    <%= label_tag :description %>
-    <%= text_field_tag :description, @item.description %>
-
-    <%= label_tag :price %>
-    <%= text_field_tag :price, @item.price %>
-
-    <%= label_tag :image %>
-    <%= text_field_tag :image, @item.image %>
-
-    <%= label_tag :inventory %>
-    <%= text_field_tag :inventory, @item.inventory %>
-
-    <%= submit_tag 'Create Item' %>
-  <% end %>
-</center>
+<%= render partial: '/partials/merchant_items_new', locals: {
+  merchant_name: @item.merchant.name,
+  merchant_path: "/merchant/#{@item.merchant.id}",
+  item_path: "/merchant/#{@item.merchant.id}/items"
+}  %>
 
 

--- a/app/views/partials/_merchant_dashboard.html.erb
+++ b/app/views/partials/_merchant_dashboard.html.erb
@@ -1,7 +1,7 @@
 <h1>Merchant Info</h1>
 <p>Employer: <%= @merchant.name %> </p>
 <p>Employer Address: <%= "#{@merchant.address} #{@merchant.city}, #{@merchant.state} #{@merchant.zip}" %></p>
-<h1><%= link_to 'My Items', '/merchant/items' %></h1>
+<h1><%= link_to 'My Items', "#{items_path}" %></h1>
 
 <h1>Order Info</h1>
 <center>

--- a/app/views/partials/_merchant_items.html.erb
+++ b/app/views/partials/_merchant_items.html.erb
@@ -1,0 +1,23 @@
+<h1>My Items - <%= link_to "#{merchant_name}", "#{items_path}" %></h1>
+<p align="center"><%= link_to "Add New Item", "#{new_item_path}/new" %></p>
+
+<section class="grid-container">
+  <% @merchant.items.each do |item| %>
+    <section class = "grid-item" id= 'item-<%=item.id%>'>
+      <%= render partial: '/partials/item_info', locals: {item: item, path: "#{items_path}/#{item.id}"}%>
+      <% if item.active? %>
+        <p>
+          Active -
+          <%= link_to "Deactivate", "#{items_path}/#{item.id}/toggle", method: :patch %>
+        </p>
+      <% else %>
+        <p>
+          Inactive -
+          <%= link_to "Activate", "#{items_path}/#{item.id}/toggle", method: :patch %>
+        </p>
+      <% end %>
+      <%= link_to "Edit", "#{items_path}/#{item.id}/edit", method: :get %>
+      <%= link_to "Delete", "#{items_path}/#{item.id}", method: :delete %>
+    </section>
+  <% end %>
+</section>

--- a/app/views/partials/_merchant_items_edit.html.erb
+++ b/app/views/partials/_merchant_items_edit.html.erb
@@ -1,0 +1,21 @@
+<h1>Edit <%=link_to @item.name, "#{item_path}" %></h1>
+<center>
+  <%= form_tag "#{item_path}", method: :patch  do %>
+    <%= label_tag :name %>
+    <%= text_field_tag :name, "#{@item.name}"%>
+
+    <%= label_tag :description %>
+    <%= text_field_tag :description, "#{@item.description}" %>
+
+    <%= label_tag :price %>
+    <%= text_field_tag :price, "#{@item.price}" %>
+
+    <%= label_tag :image %>
+    <%= text_field_tag :image, "#{@item.image}" %>
+
+    <%= label_tag :inventory %>
+    <%= number_field_tag :inventory, "#{@item.inventory}" %>
+
+    <%= submit_tag 'Update Item' %>
+  <% end %>
+</center>

--- a/app/views/partials/_merchant_items_new.html.erb
+++ b/app/views/partials/_merchant_items_new.html.erb
@@ -1,0 +1,22 @@
+<h1>Create New Item For <%=link_to "#{merchant_name}", "#{merchant_path}" %></h1>
+
+<center>
+  <%= form_tag "#{item_path}", method: :post do %>
+    <%= label_tag :name %>
+    <%= text_field_tag :name, @item.name %>
+
+    <%= label_tag :description %>
+    <%= text_field_tag :description, @item.description %>
+
+    <%= label_tag :price %>
+    <%= text_field_tag :price, @item.price %>
+
+    <%= label_tag :image %>
+    <%= text_field_tag :image, @item.image %>
+
+    <%= label_tag :inventory %>
+    <%= text_field_tag :inventory, @item.inventory %>
+
+    <%= submit_tag 'Create Item' %>
+  <% end %>
+</center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,14 @@ Rails.application.routes.draw do
     get '/users/:id/orders/:id', to: 'user_orders#show'
     patch '/users/:id/orders/:id', to: 'user_orders#update'
     get '/merchants/:id/orders/:id', to: 'merchant_orders#show'
+    get '/merchants/:id/items', to: 'merchant_items#index'
+    get '/merchants/:id/items/new', to: 'merchant_items#new'
+    post '/merchants/:id/items', to: 'merchant_items#create'
+    get '/merchants/:id/items/:id', to: 'merchant_items#show'
+    get '/merchants/:id/items/:id/edit', to: 'merchant_items#edit'
+    patch '/merchants/:id/items/:id', to: 'merchant_items#update'
+    delete '/merchants/:id/items/:id', to: 'merchant_items#destroy'
+    patch '/merchants/:id/items/:id/toggle', to: 'toggle_items#update'
     resources :users, only: %i[index show]
     resources :orders, only: [:update]
     resources :merchants, only: %i[index show update]

--- a/spec/features/admin/merchant_orders/manage_merchant_orders_spec.rb
+++ b/spec/features/admin/merchant_orders/manage_merchant_orders_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'As an admin', type: :feature do
   before :each do
-
     @user = create(:admin_user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
@@ -18,11 +17,97 @@ RSpec.describe 'As an admin', type: :feature do
     @item_order = create(:random_item_order, order: @order3, item: @item3)
   end
 
-  describe "I can click on the merchant's items link" do
-    it 'I can add new items' do
-      visit admin_merchant_path(@merchant)
+  describe "I visit a merchant's dashboard and click link 'My Items'" do
+    it 'I see all item details the merchant would see' do
+      visit "/admin/merchants/#{@merchant.id}/items"
+      save_and_open_page
+      within("#item-#{@item1.id}") do
+        expect(page).to have_link(@item1.name)
+        expect(page).to have_link(@merchant.name)
+        expect(page).to have_link('Delete')
+        expect(page).to have_link('Edit')
+        expect(page).to have_link('Deactivate')
+        expect(page).to have_content('Activate')
+        expect(page).to have_content(@item1.inventory)
+        expect(page).to have_content(@item1.price)
+        expect(page).to have_content(@item1.description)
+      end
 
-      expect(page).to have_content
+      within("#item-#{@item2.id}") do
+        expect(page).to have_link(@item2.name)
+        expect(page).to have_link(@merchant.name)
+        expect(page).to have_link('Delete')
+        expect(page).to have_link('Edit')
+        expect(page).to have_link('Deactivate')
+        expect(page).to have_content('Activate')
+        expect(page).to have_content(@item2.inventory)
+        expect(page).to have_content(@item2.price)
+        expect(page).to have_content(@item2.description)
+      end
+
+      within("#item-#{@item3.id}") do
+        expect(page).to have_link(@item3.name)
+        expect(page).to have_link(@merchant.name)
+        expect(page).to have_link('Delete')
+        expect(page).to have_link('Edit')
+        expect(page).to have_link('Deactivate')
+        expect(page).to have_content('Activate')
+        expect(page).to have_content(@item3.inventory)
+        expect(page).to have_content(@item3.price)
+        expect(page).to have_content(@item3.description)
+      end
+    end
+
+    it 'I can deactivate and activate items' do
+      within("#item-#{@item1.id}") do
+        click_link 'Deactivate'
+      end
+
+      expect(page).to have_content("#{@item1.name} is no longer for sale.")
+
+      within("#item-#{@item1.id}") do
+        click_link 'Activate'
+      end
+
+      expect(page).to have_content("#{@item1.name} is available for sale.")
+    end
+
+    it 'I can delete items' do
+
+      within("#item-#{@item3.id}") do
+        click_link 'Delete'
+      end
+
+      expect(page).to have_content("'#{@item1.name}' has been deleted.")
+    end
+
+    it 'I can edit items' do
+
+      within("#item-#{@item1.id}") do
+        click_link 'Edit'
+      end
+
+      expect(current_path).to eq("/admin/merchants/#{@merchant.id}/items/#{@item1.id}/edit")
+
+      within("#name") do
+        expect(page).to have_content(@item1.name)
+      end
+
+      within("#description") do
+        expect(page).to have_content(@item1.description)
+      end
+
+      within("#price") do
+        expect(page).to have_content(@item1.price)
+      end
+
+      within("#image") do
+        expect(page).to have_content(@item1.image.to_s)
+      end
+
+      within("#inventory") do
+        expect(page).to have_content(@item1.inventory)
+      end
     end
   end
 end

--- a/spec/features/admin/merchant_orders/manage_merchant_orders_spec.rb
+++ b/spec/features/admin/merchant_orders/manage_merchant_orders_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin', type: :feature do
+  before :each do
+
+    @user = create(:admin_user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+    @merchant = create(:random_merchant)
+    @item1 = create(:random_item, merchant: @merchant)
+    @item2 = create(:random_item, merchant: @merchant)
+    @item3 = create(:random_item, merchant: @merchant)
+    @order1 = create(:random_order)
+    @order2 = create(:random_order)
+    @order3 = create(:random_order)
+    @item_order = create(:random_item_order, order: @order1, item: @item1)
+    @item_order = create(:random_item_order, order: @order2, item: @item2)
+    @item_order = create(:random_item_order, order: @order3, item: @item3)
+  end
+
+  describe "I can click on the merchant's items link" do
+    it 'I can add new items' do
+      visit admin_merchant_path(@merchant)
+
+      expect(page).to have_content
+    end
+  end
+end
+
+# User Story 61, EXTENSION: Admin can manage items on behalf of a merchant
+
+# As an admin user
+# When I visit a merchant's profile page
+# I can click on the merchant's items link
+# And have access to all functionality the merchant does, including
+# - adding new items
+# - editing existing items
+# - enabling/disabling/deleting items
+
+# All content rules still apply (eg, item name cannot be blank, etc)


### PR DESCRIPTION
## Description

This PR adds functionality for an admin to manage merchant items in the same way that a merchant employee would.

Completes User Story #

61

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes

```
User Story 61, EXTENSION: Admin can manage items on behalf of a merchant

As an admin user
When I visit a merchant's profile page
I can click on the merchant's items link
And have access to all functionality the merchant does, including
- adding new items
- editing existing items
- enabling/disabling/deleting items

All content rules still apply (eg, item name cannot be blank, etc)
```

## RSpec Results
```
201 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/2module/projects/monster_shop_1911/coverage. 3227 / 3228 LOC (99.97%) covered.
```
